### PR TITLE
Fix helptext for `rustup update`

### DIFF
--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -21,8 +21,8 @@ toolchains are listed as well.";
 pub static UPDATE_HELP: &'static str =
 r"
 With no toolchain specified, the `update` command updates each of the
-stable, beta, and nightly toolchains from the official release
-channels, then updates rustup itself.
+installed toolchains from the official releasechannels, then updates
+rustup itself.
 
 If given a toolchain argument then `update` updates that toolchain,
 the same as `rustup toolchain update`.

--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -21,7 +21,7 @@ toolchains are listed as well.";
 pub static UPDATE_HELP: &'static str =
 r"
 With no toolchain specified, the `update` command updates each of the
-installed toolchains from the official releasechannels, then updates
+installed toolchains from the official release channels, then updates
 rustup itself.
 
 If given a toolchain argument then `update` updates that toolchain,


### PR DESCRIPTION
The issue was raised in #528 that the help text for `rustup update` does not accurately reflect the behavior. This changes the help text to more accurately describe the behavior of the update subcommand.